### PR TITLE
[Japanese]  Unify kanji for verbs with hiragana.

### DIFF
--- a/jp.js
+++ b/jp.js
@@ -755,8 +755,8 @@ account.delete アカウント削除のリクエストがされた場合、14日
 account.delete.request 本当にアカウント削除をリクエストしますか?
 account.delete.cancel 本当にアカウント削除のリクエストを取り消しますか?
 spin.free.available フリーKRが利用可能です!
-spin.free.claim このスピンは試合終了後、一時間に一回回すことが出来ます
-spin.free.disable このポップアップは設定から非表示にすることが出来ます
+spin.free.claim このスピンは試合終了後、一時間に一回回すことができます
+spin.free.disable このポップアップは設定から非表示にすることができます
 mod.reset.0 リスポーン後から有効になります
 mod.reset.1 マップのオブジェクトはリセットされません
 windows.profile.picture 写真を変更
@@ -768,13 +768,13 @@ stats.thrownkills 投げナイフキル
 stats.headshots ヘッドショット
 stats.wallbangs 壁抜きキル
 stats.sprays スプレー回数
-windows.host.default.settings デフォルト設定を有効にすることでプレイヤーの進捗とハイスコアを保存することが出来ます
+windows.host.default.settings デフォルト設定を有効にすることでプレイヤーの進捗とハイスコアを保存することができます
 windows.host.default.commands *ホストコマンド(/noclip /god /smite 等)はこのモードでは無効化されています
-windows.host.rewards KR報酬を有効にした場合デフォルト設定の使用が強制され、プレイヤーがこのマップの資産からKR報酬を入手することが出来るようになります:
+windows.host.rewards KR報酬を有効にした場合デフォルト設定の使用が強制され、プレイヤーがこのマップの資産からKR報酬を入手することができるようになります:
 windows.store.wheels.sub 新しいスキンを手に入れるためにスピンで運試しをしましょう!
 windows.store.currency * 米ドルでの金額表記はあなたの国の通貨に変換され、その際の両替レートは支払いサービスや銀行が定めたものによります
 windows.store.creator クリエイターコードを使ってあなたのお気に入りのクリエイターを支援しましょう
-windows.chall.customs カスタムマッチ内でチャレンジをクリアすることは出来ません
+windows.chall.customs カスタムマッチ内でチャレンジをクリアすることはできません
 twitch.link 本当にtwitchアカウントとリンクしますか?
 twitch.unlink 本当にtwitchアカウントとのリンクを解除しますか?
 windows.clan.leave 本当にこのクランを離れますか?


### PR DESCRIPTION
# [Japanese]  Unify kanji for verbs with hiragana.

## Description

+ The sentences where kanji were used as verbs have been unified into hiragana.

## Issues
+ [#220 [Japanese] Fixing incomplete translations and translations that don't match the guide.](https://github.com/mty22/krunker.io-translations/issues/220)