### PR TITLE
Remove @apinklover from Korean translators

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,7 +20,7 @@ fr.js @enygmate
 jp.js @Hiro527 @hassich
 
 # Korean
-kr.js @dojinshi @YuniQ152 @apinklover @Baw-Appie @GoonMandu
+kr.js @dojinshi @YuniQ152 @goonmandu @Baw-Appie
 
 # Portuguese
 pr.js @xlNightmare


### PR DESCRIPTION
@apinklover is my old name. I've changed it since.